### PR TITLE
Fix typo: `*-tt-mod-symbol` -> `*-tty-mod-symbol`

### DIFF
--- a/bespoke-modeline.el
+++ b/bespoke-modeline.el
@@ -461,7 +461,7 @@ modified (⨀)/(**), or read-write (◯)/(RW)"
                                    'bespoke-modeline-inactive-status-RO)))
                          ((string= status bespoke-modeline-tty-mod-symbol)
                           (propertize
-                           (if (window-dedicated-p) " -- " bespoke-modeline-tt-mod-symbol)
+                           (if (window-dedicated-p) " -- " bespoke-modeline-tty-mod-symbol)
                            'face (if active
                                      'bespoke-modeline-active-status-**
                                    'bespoke-modeline-inactive-status-**)))


### PR DESCRIPTION
Without this commit, the error "Error during redisplay: ..." will occur when the buffer is in modified state in tty.

```
Error during redisplay: (eval (cond ((bespoke-modeline-user-mode-p) (funcall (\, bespoke-modeline-user-mode))) ((bespoke-modeline-prog-mode-p) (bespoke-modeline-default-mode)) ((bespoke-modeline-message-mode-p) (bespoke-modeline-message-mode)) ((bespoke-modeline-elfeed-search-mode-p) (bespoke-modeline-elfeed-search-mode)) ((bespoke-modeline-elfeed-show-mode-p) (bespoke-modeline-elfeed-show-mode)) ((bespoke-modeline-deft-mode-p) (bespoke-modeline-deft-mode)) ((bespoke-modeline-info-mode-p) (bespoke-modeline-info-mode)) ((bespoke-modeline-calendar-mode-p) (bespoke-modeline-calendar-mode)) ((bespoke-modeline-org-capture-mode-p) (bespoke-modeline-org-capture-mode)) ((bespoke-modeline-org-agenda-mode-p) (bespoke-modeline-org-agenda-mode)) ((bespoke-modeline-org-clock-mode-p) (bespoke-modeline-org-clock-mode)) ((bespoke-modeline-term-mode-p) (bespoke-modeline-term-mode)) ((bespoke-modeline-vterm-mode-p) (bespoke-modeline-term-mode)) ((bespoke-modeline-mu4e-dashboard-mode-p) (bespoke-modeline-mu4e-dashboard-mode)) ((bespoke-modeline-mu4e-main-mode-p) (bespoke-modeline-mu4e-main-mode)) ((bespoke-modeline-mu4e-loading-mode-p) (bespoke-modeline-mu4e-loading-mode)) ((bespoke-modeline-mu4e-headers-mode-p) (bespoke-modeline-mu4e-headers-mode)) ((bespoke-modeline-mu4e-view-mode-p) (bespoke-modeline-mu4e-view-mode)) ((bespoke-modeline-text-mode-p) (bespoke-modeline-default-mode)) ((bespoke-modeline-pdf-view-mode-p) (bespoke-modeline-pdf-view-mode)) ((bespoke-modeline-docview-mode-p) (bespoke-modeline-docview-mode)) ((bespoke-modeline-buffer-menu-mode-p) (bespoke-modeline-buffer-menu-mode)) ((bespoke-modeline-completion-list-mode-p) (bespoke-modeline-completion-list-mode)) ((bespoke-modeline-bespoke-help-mode-p) (bespoke-modeline-bespoke-help-mode)) (t (bespoke-modeline-default-mode)))) signaled (void-variable bespoke-modeline-tt-mod-symbol) [5 times]
```